### PR TITLE
Refactor the osquery sql validator into a WTForms style field validor

### DIFF
--- a/doorman/forms.py
+++ b/doorman/forms.py
@@ -8,7 +8,20 @@ from wtforms.fields import (IntegerField,
                             SelectMultipleField,
                             StringField,
                             TextAreaField)
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired, ValidationError
+
+from doorman.utils import validate_osquery_query
+
+
+class ValidSQL(object):
+    def __init__(self, message=None):
+        if not message:
+            message = u'Field must contain valid SQL to be run against osquery tables'
+        self.message = message
+
+    def __call__(self, form, field):
+        if not validate_osquery_query(field.data):
+            raise ValidationError(self.message)
 
 
 class UploadPackForm(Form):
@@ -19,7 +32,7 @@ class UploadPackForm(Form):
 class QueryForm(Form):
 
     name = StringField('Name', validators=[DataRequired()])
-    sql = TextAreaField("Query", validators=[DataRequired()])
+    sql = TextAreaField("Query", validators=[DataRequired(), ValidSQL()])
     interval = IntegerField('Interval', default=3600, validators=[DataRequired()])
     platform = SelectField('Platform', default='all', choices=[
         ('all', 'All'),

--- a/doorman/utils.py
+++ b/doorman/utils.py
@@ -268,3 +268,13 @@ def extract_batch(batch):
                     timestamp,
                     item['diffResults']['added'],
                     item['diffResults']['removed'])
+
+
+def flash_errors(form):
+    '''http://flask.pocoo.org/snippets/12/'''
+    for field, errors in form.errors.items():
+        for error in errors:
+            flash(u"Error in the %s field - %s" % (
+                getattr(form, field).label.text,
+                error
+            ))

--- a/doorman/views.py
+++ b/doorman/views.py
@@ -12,7 +12,7 @@ from doorman.forms import (
 )
 from doorman.database import db
 from doorman.models import FilePath, Node, Pack, Query, Tag
-from doorman.utils import create_query_pack_from_upload, validate_osquery_query
+from doorman.utils import create_query_pack_from_upload, flash_errors
 
 
 blueprint = Blueprint('manage', __name__,
@@ -85,6 +85,7 @@ def add_pack():
         if pack is not None:
             return redirect(url_for('.packs', _anchor=pack.name))
 
+    flash_errors(form)
     return render_template('pack.html', form=form)
 
 
@@ -112,10 +113,6 @@ def add_query():
     form.set_choices()
 
     if form.validate_on_submit():
-        if not validate_osquery_query(form.sql.data):
-            flash(u'Invalid osquery query: "{0}"'.format(form.sql.data), 'danger')
-            return render_template('query.html', form=form)
-
         query = Query(name=form.name.data,
                       sql=form.sql.data,
                       interval=form.interval.data,
@@ -128,6 +125,7 @@ def add_query():
 
         return redirect(url_for('.query', query_id=query.id))
 
+    flash_errors(form)
     return render_template('query.html', form=form)
 
 
@@ -160,6 +158,7 @@ def query(query_id):
         return redirect(url_for('.query', query_id=query.id))
 
     form = UpdateQueryForm(request.form, obj=query)
+    flash_errors(form)
     return render_template('query.html', form=form, query=query)
 
 
@@ -189,6 +188,7 @@ def add_file():
                         target_paths=form.target_paths.data.splitlines())
         return redirect(url_for('.files'))
 
+    flash_errors(form)
     return render_template('file.html', form=form)
 
 
@@ -217,6 +217,8 @@ def add_tag():
     if form.validate_on_submit():
         create_tags(*form.value.data.splitlines())
         return redirect(url_for('.tags'))
+
+    flash_errors(form)
     return render_template('tag.html', form=form)
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -7,6 +7,8 @@ from doorman.forms import (
     CreateTagForm,
 )
 
+from .factories import QueryFactory
+
 
 class TestCreateTagForm:
 
@@ -20,8 +22,46 @@ class TestCreateTagForm:
 
 
 class TestCreateQueryForm:
-    pass
+
+    def test_sql_validate_failure(self, testapp, db):
+        form = CreateQueryForm(
+            name='foobar',
+            sql='select * from foobar;'
+        )
+        assert form.validate() is False
+        assert 'sql' in form.errors
+        assert 'name' not in form.errors
+
+    def test_sql_validate_success(self, testapp, db):
+        form = CreateQueryForm(
+            name='foobar',
+            sql='select * from osquery_info;',
+        )
+        assert form.validate() is True
 
 
 class TestUpdateQueryForm:
-    pass
+
+    def test_sql_validate_failure(self, testapp, db):
+        query = QueryFactory(
+            name='foobar',
+            sql='select * from osquery_info;'
+        )
+        form = UpdateQueryForm(
+            name=query.name,
+            sql='select * from foobar;'
+        )
+        assert form.validate() is False
+        assert 'sql' in form.errors
+        assert 'name' not in form.errors
+
+    def test_sql_validate_success(self, testapp, db):
+        query = QueryFactory(
+            name='foobar',
+            sql='select * from osquery_info;'
+        )
+        form = UpdateQueryForm(
+            name=query.name,
+            sql='select * from platform_info;'
+        )
+        assert form.validate() is True


### PR DESCRIPTION
We weren't validating sql when updating a query. This PR turns the sql validator into something more generally applicable to a WTForm. Plus more tests.