### PR TITLE
[WIP] Beginnings of a search api

### DIFF
--- a/doorman/templates/manage/results.html
+++ b/doorman/templates/manage/results.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %}
+{% block content %}
+
+    <div class="body-content">
+        <div class="row">
+            <div class="col-md-12">
+                <h1>search results</h1>
+
+                {% if results | list %}
+                {% include "tables/results.html" %}
+                <div class="text-center">
+                    <small>{{ pagination.info }}</small>
+                    {{ pagination.links }}
+                </div>
+                {% else %}
+                <p>No results for this search.<p>
+                {% endif %}
+
+            </div>
+        </div>
+    </div>
+
+{% endblock %}

--- a/doorman/templates/manage/tables/results.html
+++ b/doorman/templates/manage/tables/results.html
@@ -1,0 +1,38 @@
+                {% set columns = results | first | attr('columns') | list | sort %}
+
+                <div class="table-responsive">
+                    <table class="table table-striped table-condensed">
+                        <thead>
+                            <th>node</th>
+                            <th>activity</th>
+                            <th>timestamp</th>
+                            {% for column in columns %}
+                            <th>{{ column }}</th>
+                            {% endfor %}
+                        </thead>
+
+                        <tbody>
+                            {% for result in results %}
+                            <tr>
+                                <td>
+                                    {% if result.node is defined %}
+                                    <a href="{{ url_for('.get_node', node_id=result.node.id) }}">{{ result.node.host_identifier }}</a>
+                                    {% elif result.distributed_query is defined %}
+                                    <a href="{{ url_for('.get_node', node_id=result.distributed_query.node.id) }}">{{ result.distributed_query.node.host_identifier }}</a>
+                                    {% endif %}
+                                </td>
+                                <td>{{ result.action }}</td>
+                                <td>{{ result.timestamp }}</td>
+                                {% for column in columns %}
+                                <td>
+                                    <a href="{{ url_for('manage.search', **{'columns.' + column: result.columns[column]}) }}">
+                                    {{ result.columns[column] }}
+                                    </a>
+                                </td>
+                                {% endfor %}
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+
+                    </table>
+                </div>


### PR DESCRIPTION
This provides the very beginnings for a search API. Results can be queried by passing any number of query string parameters, i.e., `/manage/search?columns.removable=1&columns.usb_port=5&columns.usb_port=12`, would return all results where `removable=1 AND (usb_port=5 OR usb_port=12)`. The idea here is you can click on an existing key/value in a table and it'll perform a search across all results for that key/value pair, and try to normalize the results. This allows you to quickly query the results table for nodes that returned the same key/values.

I don't think it's worth expanding too much effort into making the query syntax anymore sophisticated, as that'd likely require writing a DSL, and frankly, there are better tools for the job (e.g., Elasticsearch).

Some work could be done on the following still:
- limit the number of keys / values searched to avoid a DoS
- some attempt to normalize the results (there's nothing to really JOIN these on, so if the same key/value is returned in multiple queries, do we create a table listing all the columns and leave blank values for results that don't contain those keys?)
- search across distributed query results versus regular results
