### PR TITLE
Add Flask-DebugToolbar to requirements and add a MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include doorman/templates *
+recursive-include doorman/static *
+recursive-include doorman/resources *

--- a/doorman/api.py
+++ b/doorman/api.py
@@ -75,6 +75,11 @@ def node_required(f):
     return decorated_function
 
 
+@blueprint.route('/')
+def index():
+    return '', 204
+
+
 @blueprint.route('/enroll', methods=['POST'])
 @blueprint.route('/v1/enroll', methods=['POST'])
 def enroll():

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -7,6 +7,7 @@ celery==3.1.23
 cssmin==0.2.0
 Flask==0.10.1
 Flask-Assets==0.11
+Flask-DebugToolbar==0.10.0
 Flask-Migrate==1.8.0
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.1

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'WTForms==2.1',
     ],
     package_data={
+        'resources': 'doorman/resources/*',
         'static': 'doorman/static/*',
         'templates': 'doorman/templates/*',
     }


### PR DESCRIPTION
Flask-DebugToolbar is needed by the application (though can be explicitly enabled/disabled), and MANIFEST.in allows us to include the templates and other non-py files in our package.