### PR TITLE
Pagination and tabs

### DIFF
--- a/doorman/templates/manage/_activity.html
+++ b/doorman/templates/manage/_activity.html
@@ -1,43 +1,61 @@
 
-                <ul>
+                <ul class="nav nav-tabs">
                 {% for group in node.get_recent() | groupby('name') %}
-                    <li><a href="#{{ group.grouper }}">{{ group.grouper }}</a></li>
+                    <li class="{% if loop.first %}active{% endif %}">
+                        <a href="#{{ group.grouper }}" aria-controls="{{ group.grouper }}" role="tab" data-toggle="tab">{{ group.grouper }}
+                            <span class="badge">{{ group.list | count }}</span>
+                        </a>
+                    </li>
                 {% endfor %}
+                    {% if queries.count() %}
+                    <li class="{% if not node.get_recent() %}active{% endif %}">
+                        <a href="#distributed_queries" aria-controls="distributed_queries" role="tab" data-toggle="tab">distributed queries
+                            </span class="badge">{{ queries.count() or '' }}</span>
+                        </a>
+                    </li>
+                    {% endif %}
                 </ul>
 
+                <div class="tab-content">
 
-                {% for grouper, results in node.get_recent() | groupby('name') %}
+                    {% for grouper, results in node.get_recent() | groupby('name') %}
 
-                <div id="{{ grouper }}">
-                    
-                <h3>{{ grouper }}</h3>
+                    <div class="tab-pane{% if loop.first %} active{% endif %}" id="{{ grouper }}">
 
-                {% set columns = results | first | attr('columns') | list | sort %}
+                    {% set columns = results | first | attr('columns') | list | sort %}
 
-                <div class="table-responsive">
-                    <table class="table table-striped table-condensed">
-                        <thead>
-                            <th>activity</th>
-                            <th>timestamp</th>
-                            {% for column in columns %}
-                            <th>{{ column }}</th>
-                            {% endfor %}
-                        </thead>
-                        <tbody>
-                            {% for result in results %}
-                            <tr>
-                                <td>{{ result.action }}</td>
-                                <td>{{ result.timestamp }}</td>
+                    <div class="table-responsive">
+                        <table class="table table-striped table-condensed">
+                            <thead>
+                                <th>activity</th>
+                                <th>timestamp</th>
                                 {% for column in columns %}
-                                <td>{{ result.columns[column] }}</td>
+                                <th>{{ column }}</th>
                                 {% endfor %}
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
+                            </thead>
+                            <tbody>
+                                {% for result in results %}
+                                <tr>
+                                    <td>{{ result.action }}</td>
+                                    <td>{{ result.timestamp }}</td>
+                                    {% for column in columns %}
+                                    <td>{{ result.columns[column] }}</td>
+                                    {% endfor %}
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
 
-                </div>
+                    </div>
+
                 {% endfor %}
 
+                    {% if queries.count() %}
+                    <div class="tab-pane" id="distributed_queries">
+                        {% include "tables/distributed.html" %}
+                    </div>
+                    {% endif %}
+
+                </div>
 

--- a/doorman/templates/manage/activity.html
+++ b/doorman/templates/manage/activity.html
@@ -6,21 +6,12 @@
             <div class="col-md-12">
                 <h1>recent activity</h1>
 
-                {% if node.get_recent().count() %}
+                {% if node.get_recent().count() or node.distributed_queries.count() %}
+                {% set queries = node.distributed_queries %}
                 {% include "_activity.html" %}
                 {% else %}
                 <p>No recent activity for this node.<p>
                 {% endif %}
-
-                {% if node.distributed_queries.count() %}
-                <h1>distributed queries</h1>
-
-                {% set queries = node.distributed_queries %}
-                {% include "tables/distributed.html" %}
-                {% else %}
-                <p>No recent distributed queries for this node.</p>
-                {% endif %}
-
             </div>
         </div>
     </div>

--- a/doorman/templates/manage/nodes.html
+++ b/doorman/templates/manage/nodes.html
@@ -8,6 +8,11 @@
                 
                 {% if nodes %}
                 {% include "tables/nodes.html" %}
+
+                <div class="text-center">
+                    {{ pagination.links }}
+                </div>
+
                 {% elif request.endpoint == url_for('manage.nodes') %}
                 <p>No nodes have enrolled yet!</p>
                 {% endif %}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,6 +12,7 @@ Flask==0.10.1
 Flask-Assets==0.11
 Flask-DebugToolbar==0.10.0
 Flask-Migrate==1.8.0
+flask-paginate==0.4.1
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.1
 Flask-WTF==0.12

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -9,6 +9,7 @@ Flask==0.10.1
 Flask-Assets==0.11
 Flask-DebugToolbar==0.10.0
 Flask-Migrate==1.8.0
+flask-paginate==0.4.1
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.1
 Flask-WTF==0.12


### PR DESCRIPTION
Added pagination to the nodes page, displaying a maximum of 20 nodes per page. Also use tabs to display and organize recent activity for a node, rather than dump it all together. 

Addresses most of #23. Some ui tweaks could be added to enable the ordering and sorting.