### PR TITLE
Support deploying just the API by setting an env var

### DIFF
--- a/doorman/application.py
+++ b/doorman/application.py
@@ -73,6 +73,8 @@ def register_errorhandlers(app):
         """Render error template."""
         # If a HTTPException, pull the `code` attribute; default to 500
         error_code = getattr(error, 'code', 500)
+        if 'DOORMAN_NO_MANAGER' in os.environ:
+            return '', 400
         return render_template('{0}.html'.format(error_code)), error_code
 
     for errcode in [401, 403, 404, 500]:

--- a/doorman/application.py
+++ b/doorman/application.py
@@ -30,7 +30,13 @@ def create_app(config=ProdConfig):
 
 def register_blueprints(app):
     app.register_blueprint(api)
-    app.register_blueprint(backend)
+
+    # if the DOORMAN_NO_MANAGER environment variable isn't set,
+    # register the backend blueprint. This is useful when you want
+    # to only deploy the api as a standalone service.
+
+    if 'DOORMAN_NO_MANAGER' not in os.environ:
+        app.register_blueprint(backend)
 
 
 def register_extensions(app):

--- a/doorman/application.py
+++ b/doorman/application.py
@@ -35,8 +35,10 @@ def register_blueprints(app):
     # register the backend blueprint. This is useful when you want
     # to only deploy the api as a standalone service.
 
-    if 'DOORMAN_NO_MANAGER' not in os.environ:
-        app.register_blueprint(backend)
+    if 'DOORMAN_NO_MANAGER' in os.environ:
+        return
+
+    app.register_blueprint(backend)
 
 
 def register_extensions(app):


### PR DESCRIPTION
If `DOORMAN_NO_MANAGER` environment variable is set, then Doorman will return an app containing only the API endpoints.