### PR TITLE
Display tabs vertically instead of horizontally

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
     "jQuery": "~2.1.3",
     "font-awesome": "~4.5.0",
     "bootstrap-tagsinput": "~0.8.0",
+    "bootstrap-vertical-tabs": "~1.2.1",
     "jQuery-QueryBuilder": "^2.3.3"
   }
 }

--- a/doorman/assets.py
+++ b/doorman/assets.py
@@ -8,6 +8,7 @@ css = Bundle(
            filters='less',
     ),
     'libs/bootstrap-tagsinput/dist/bootstrap-tagsinput.css',
+    'libs/bootstrap-vertical-tabs/bootstrap.vertical-tabs.css',
     'libs/jQuery-QueryBuilder/dist/css/query-builder.default.css',
     'css/style.css',
     filters='cssmin',

--- a/doorman/templates/manage/_activity.html
+++ b/doorman/templates/manage/_activity.html
@@ -1,5 +1,6 @@
 
-                <ul class="nav nav-tabs" role="tablist">
+            <div class="col-md-3">
+                <ul class="nav nav-tabs tabs-left" role="tablist">
                     {% if queries.count() %}
                     <li class="active">
                         <a href="#distributed_queries" aria-controls="distributed_queries" role="tab" data-toggle="tab">distributed queries
@@ -16,7 +17,9 @@
                     </li>
                     {% endfor %}
                 </ul>
+            </div>
 
+            <div class="col-md-9">
                 <div class="tab-content">
 
                     {% if queries.count() %}
@@ -60,3 +63,4 @@
                     {% endfor %}
 
                 </div><!-- ./tab-content -->
+            </div>


### PR DESCRIPTION
Way cleaner to display query results this way versus horizontally, causing tabs to spill over into multiple lines, pushing the actual content down the page.