### PR TITLE
Rule fixes

### DIFF
--- a/doorman/plugins/logs/file.py
+++ b/doorman/plugins/logs/file.py
@@ -82,7 +82,7 @@ class LogPlugin(AbstractLogsPlugin):
 
             # Write each added/removed entry on a different line
             curr_fields = {'result_type': item.action}
-            for key, val in entry.columns.items():
+            for key, val in item.columns.items():
                 curr_fields['_'.join([item.action, key])] = val
 
             self.result.write(base + ', ' + self.join_fields(curr_fields) + '\n')

--- a/doorman/rules.py
+++ b/doorman/rules.py
@@ -98,7 +98,7 @@ class Network(object):
                 # Strip 'column_' prefix to get the 'real' operator.
                 op = op[7:]
 
-                if isinstance(value, basestring):
+                if isinstance(value, six.string_types):
                     column_name = value
                 else:
                     # The 'value' array will look like ['column_name', 'actual value']

--- a/doorman/rules.py
+++ b/doorman/rules.py
@@ -260,12 +260,12 @@ class LogicCondition(BaseCondition):
 
 class EqualCondition(LogicCondition):
     def compare(self, value):
-        return self.expected == value
+        return value == self.expected
 
 
 class NotEqualCondition(LogicCondition):
     def compare(self, value):
-        return self.expected != value
+        return value != self.expected
 
 
 class BeginsWithCondition(LogicCondition):
@@ -310,22 +310,22 @@ class IsNotEmptyCondition(LogicCondition):
 
 class LessCondition(LogicCondition):
     def compare(self, value):
-        return self.expected < value
+        return value < self.expected
 
 
 class LessEqualCondition(LogicCondition):
     def compare(self, value):
-        return self.expected <= value
+        return value <= self.expected
 
 
 class GreaterCondition(LogicCondition):
     def compare(self, value):
-        return self.expected > value
+        return value > self.expected
 
 
 class GreaterEqualCondition(LogicCondition):
     def compare(self, value):
-        return self.expected >= value
+        return value >= self.expected
 
 
 class MatchesRegexCondition(LogicCondition):

--- a/doorman/rules.py
+++ b/doorman/rules.py
@@ -98,8 +98,11 @@ class Network(object):
                 # Strip 'column_' prefix to get the 'real' operator.
                 op = op[7:]
 
-                # The 'value' array will look like ['column_name', 'actual value']
-                column_name, value = value
+                if isinstance(value, basestring):
+                    column_name = value
+                else:
+                    # The 'value' array will look like ['column_name', 'actual value']
+                    column_name, value = value
 
             klass = OPERATOR_MAP.get(op)
             if not klass:

--- a/doorman/templates/manage/_rule.html
+++ b/doorman/templates/manage/_rule.html
@@ -30,8 +30,10 @@
                                             {{ item.condition }}<br/>
                                             <ul>{{ loop(item.rules) }}</ul>
                                         {%- else -%}
-                                            {%- if item.operator.startswith('column_') %}
+                                            {%- if item.operator.startswith('column_') and not item.operator.endswith('_empty') %}
                                                 Column "{{ item.value[0] }}" {{ item.operator[7:] | pretty_operator }} "{{ item.value[1] }}"
+                                            {%- elif item.operator.startswith('column_') and item.operator.endswith('_empty') %}
+                                                Column "{{ item.value }}" {{ item.operator[7:] | pretty_operator }}
                                             {%- else -%}
                                                 {{ item.id | pretty_field }} {{ item.operator | pretty_operator }} "{{ item.value }}"
                                             {%- endif %}


### PR DESCRIPTION
This PR fixes some issues we have with the empty/not empty rule operator, as well as flips the less (than) / greater (than) conditionals to be inline with what you'd expect during comparison.

Also fixes bug reported by @grantstavely in file logger plugin.