### PR TITLE
Sentry alerter

### DIFF
--- a/doorman/models.py
+++ b/doorman/models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime as dt
+import string
 import uuid
 
 from flask_login import UserMixin
@@ -478,6 +479,11 @@ class Rule(SurrogatePK, Model):
         self.conditions = conditions
         self.updated_at = updated_at
 
+    @property
+    def template(self):
+        return string.Template(
+            "{rule.name}\r\n\r\n{rule.description}".format(rule=self)
+        )
 
 class User(UserMixin, SurrogatePK, Model):
 

--- a/doorman/models.py
+++ b/doorman/models.py
@@ -481,8 +481,8 @@ class Rule(SurrogatePK, Model):
 
     @property
     def template(self):
-        return string.Template(
-            "{rule.name}\r\n\r\n{rule.description}".format(rule=self)
+        return string.Template("{name}\r\n\r\n{description}".format(
+            name=self.name, description=self.description or '')
         )
 
 class User(UserMixin, SurrogatePK, Model):

--- a/doorman/plugins/alerters/pagerduty.py
+++ b/doorman/plugins/alerters/pagerduty.py
@@ -30,9 +30,12 @@ class PagerDutyAlerter(AbstractAlerterPlugin):
             count=self.incident_count
         )
 
-        description = match.rule.name
-        if match.rule.description:
-            description = "{0}: {1}".format(description, match.rule.description)
+        description = match.rule.template.safe_substitute(
+            match.result['columns'],
+            **node
+        ).rstrip()
+
+        description = ":".join(description.split('\r\n\r\n', 1))
 
         details = {
             'node': node,

--- a/doorman/plugins/alerters/sentry.py
+++ b/doorman/plugins/alerters/sentry.py
@@ -29,7 +29,7 @@ class SentryAlerter(AbstractAlerterPlugin):
 
         message = match.rule.template.safe_substitute(
             match.result['columns'],
-            **node,
+            **node
         )
 
         self.client.captureMessage(

--- a/doorman/plugins/alerters/sentry.py
+++ b/doorman/plugins/alerters/sentry.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import string
+
+from flask import current_app
+from raven import Client
+
+from .base import AbstractAlerterPlugin
+
+
+class SentryAlerter(AbstractAlerterPlugin):
+    def __init__(self, config):
+        self.client = Client(
+            config['dsn'],
+            auto_log_stacks=False,
+            enable_breadcrumbs=False,
+        )
+        self.config = config
+
+    def handle_alert(self, node, match):
+        name = match.result['name']
+
+        if name.startswith('pack'):
+            try:
+                _, pack, query = name.split(current_app.config['DOORMAN_PACK_DELIMITER'])
+            except ValueError:
+                pack, query = None, name
+        else:
+            pack, query = None, name
+
+        message = match.rule.template.safe_substitute(
+            match.result['columns'],
+            **node,
+        )
+
+        self.client.captureMessage(
+            message=message.rstrip(),
+            data={
+                'logger': current_app.name
+            },
+            extra={
+                'action': match.result['action'],
+                'columns': match.result['columns'],
+                'timestamp': match.result['timestamp'].strftime('%Y-%m-%d %H:%M:%S'),
+                'node': node,
+            },
+            tags={
+                'host_identifier': node.get('host_identifier'),
+                'pack': pack,
+                'query': query,
+            },
+        )

--- a/doorman/settings.py
+++ b/doorman/settings.py
@@ -115,6 +115,10 @@ class Config(object):
         #     'message_template': '',
 
         # }),
+
+        # 'sentry': ('doorman.plugins.alerters.sentry.SentryAlerter', {
+        #     'dsn': 'https://<key>:<secret>@app.getsentry.com/<project>',
+        # })
     }
 
     # MAIL_SERVER = 'localhost'

--- a/doorman/templates/manage/forms/rule.html
+++ b/doorman/templates/manage/forms/rule.html
@@ -18,6 +18,11 @@
                             {{ form.description.label(class_="col-sm-2 control-label") }}
                             <div class="col-sm-10">
                                 {{ form.description(class_="form-control") }}
+                                <small>
+                                    Note: Rule names and descriptions may be treated as <a href="https://docs.python.org/dev/library/string.html#template-strings">Template strings</a> for <em>some</em> alerters.
+                                    Valid placeholders may include column keys returned in query results and/or node attributes (i.e., <tt>host_identifier</tt>, <tt>enrolled_on</tt>).
+                                    A missing placeholder will result in the original placeholder to appear in the resulting string intact.
+                                </small>
                             </div>
                         </div>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,7 @@ def node(db):
 def rule(db):
     rule = RuleFactory(
         name='testrule',
+        description='kung = $kung',
         alerters=[],
         conditions={}
     )


### PR DESCRIPTION
This PR adds a new alerter for Sentry. The `doorman.plugins.alerts.sentry.SentryAlerter` alerter plugin will send alerts to Sentry if configured.

Additionally, this PR adds Sentry alerting to Celery, along with support for treating rule names and descriptions as template strings. 