### PR TITLE
Better pack upload error handling

### DIFF
--- a/doorman/utils.py
+++ b/doorman/utils.py
@@ -121,9 +121,19 @@ def create_query_pack_from_upload(upload):
     if not isinstance(body, six.string_types):
         body = body.decode('utf-8')
 
-    data = json.loads(body)
-    name = splitext(basename(upload.data.filename))[0]
-    pack = Pack.query.filter(Pack.name == name).first()
+    try:
+        data = json.loads(body)
+    except ValueError:
+        flash(u"Could not load pack as JSON - ensure it is JSON encoded",
+              'danger')
+        return None
+    else:
+        if 'queries' not in data:
+            flash(u"No queries in pack", 'danger')
+            return None
+
+        name = splitext(basename(upload.data.filename))[0]
+        pack = Pack.query.filter(Pack.name == name).first()
 
     if not pack:
         current_app.logger.debug("Creating pack %s", name)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1066,7 +1066,7 @@ class TestCreateQueryPackFromUpload:
 
     def test_pack_upload_invalid_json(self, testapp, db):
         resp = testapp.post(url_for('manage.add_pack'), upload_files=[
-            ('pack', 'foo.conf', 'bad data'),
+            ('pack', 'foo.conf', 'bad data'.encode('utf-8')),
         ])
 
         # This won't be a redirect, since it's an error.

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1047,6 +1047,40 @@ class TestCreateQueryPackFromUpload:
         innerText = ''.join(flashes[0].findAll(text=True, recursive=False))
         assert innerText.strip() == msg
 
+    def test_pack_upload_invalid_empty_object(self, testapp, db):
+        resp = testapp.post(url_for('manage.add_pack'), upload_files=[
+            ('pack', 'foo.conf', json.dumps({}).encode('utf-8')),
+        ])
+
+        # This won't be a redirect, since it's an error.
+        assert resp.status_int == 200
+
+        body = resp.html
+        flashes = body.select('.alert.alert-danger')
+
+        assert len(flashes) == 1
+
+        msg = 'No queries in pack'
+        innerText = ''.join(flashes[0].findAll(text=True, recursive=False))
+        assert innerText.strip() == msg
+
+    def test_pack_upload_invalid_json(self, testapp, db):
+        resp = testapp.post(url_for('manage.add_pack'), upload_files=[
+            ('pack', 'foo.conf', 'bad data'),
+        ])
+
+        # This won't be a redirect, since it's an error.
+        assert resp.status_int == 200
+
+        body = resp.html
+        flashes = body.select('.alert.alert-danger')
+
+        assert len(flashes) == 1
+
+        msg = 'Could not load pack as JSON - ensure it is JSON encoded'
+        innerText = ''.join(flashes[0].findAll(text=True, recursive=False))
+        assert innerText.strip() == msg
+
     def test_pack_does_not_exist_but_query_does(self, testapp, db):
         query = QueryFactory(name='foobar', sql='select * from osquery_info;')
 


### PR DESCRIPTION
Addresses any `ValueError` or `KeyError` exceptions raised when uploading empty packs or packs with non-json data.