### PR TITLE
Updating path to runit in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 # Install Python
-RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
   && apk add --update \
               bash \
               build-base \
@@ -14,7 +14,7 @@ RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/
               python \
               python-dev \
               redis \
-              runit@testing \
+              runit \
   && pip install --upgrade pip \
   && npm install -g bower less \
   && rm /var/cache/apk/*


### PR DESCRIPTION
Runit no longer appears to be in testing. When attempting to build the dockerfile on Ubuntu 16.04 and OSX 10.11, I received the following error:

```
# docker build -t doorman .
Sending build context to Docker daemon 1.838 MB
Step 1 : FROM alpine:latest
 ---> 7d23b3ca3463
Step 2 : RUN apk update
 ---> Running in 2752fc94a38c
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
v3.4.3-66-gc73e68d [http://dl-cdn.alpinelinux.org/alpine/v3.4/main]
v3.4.3-62-gaaf1b40 [http://dl-cdn.alpinelinux.org/alpine/v3.4/community]
OK: 5968 distinct packages available
 ---> e004eba74087
Removing intermediate container 2752fc94a38c
Step 3 : RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories   && apk add --update               bash               build-base               git               libffi-dev               musl               nodejs               postgresql-dev               py-pip               python               python-dev               redis               runit@testing   && pip install --upgrade pip   && npm install -g bower less   && rm /var/cache/apk/*
 ---> Running in fe4e8398c569
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
fetch http://dl-4.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  runit (missing):
    required by: world[runit]
The command '/bin/sh -c echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories   && apk add --update               bash               build-base               git               libffi-dev               musl               nodejs               postgresql-dev               py-pip               python               python-dev               redis               runit@testing   && pip install --upgrade pip   && npm install -g bower less   && rm /var/cache/apk/*' returned a non-zero code: 1
```

Updating the path to the APK repos fixed this issue on both operating systems and the Dockerfile then was able to build successfully.