### PR TITLE
Add interact.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "font-awesome": "~4.5.0",
     "bootstrap-tagsinput": "~0.8.0",
     "bootstrap-vertical-tabs": "~1.2.1",
-    "jQuery-QueryBuilder": "^2.3.3"
+    "jQuery-QueryBuilder": "^2.3.3",
+    "interact": "^1.2.6"
   }
 }

--- a/doorman/assets.py
+++ b/doorman/assets.py
@@ -21,6 +21,7 @@ js = Bundle(
     'libs/bootstrap-tagsinput/dist/bootstrap-tagsinput.js',
     'libs/jquery-extendext/jQuery.extendext.js',
     'libs/jQuery-QueryBuilder/dist/js/query-builder.standalone.js',
+    'libs/interact/interact.js',
     'js/plugins.js',
     filters='jsmin',
     output='public/js/common.js',


### PR DESCRIPTION
`Doorman` displays the following error in `/manage/rules/add`.
>query-builder.standalone.js:2943 Uncaught Error: interact.js is required to use "sortable" plugin. Get it here: http://interactjs.io

This is because `jQuery-QueryBuilder` implemented `interact.js`
https://github.com/mistic100/jQuery-QueryBuilder/commit/221eb4f9906659c85c8f9334d6724aafda601c83#diff-d23309cd66d33b4200455ba8287dbca4R11

I sent Pull Request to `jQuery-QueryBuilder` to move `interact` from `devDependencies` to `dependencies`.
https://github.com/mistic100/jQuery-QueryBuilder/pull/396

I received the following answer
>I put it in dev dependencies because it's not a required component for the basic use of the library, it's the same for every dependency of query builder plugins.

So, I think that `Doorman` should add `interact.js` to `devendencies`.
How about this proposal?

At least, if I don't install `interact.js`, I get an error.
Please tell me if there is any other good way.
Thanks!