### PR TITLE
Fix Dockerfile: Add nodejs-npm package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repos
               libffi-dev \
               musl \
               nodejs \
+              nodejs-npm \
               postgresql-dev \
               py2-pip \
               python \


### PR DESCRIPTION
When using the latest alpine-package, npm is not part of the nodejs package
anymore. Installing nodejs-npm will provide the npm binary.