### PR TITLE
Don't force DOORMAN_ENV to prod in the docker config

### DIFF
--- a/docker/service/api/run
+++ b/docker/service/api/run
@@ -2,7 +2,9 @@
 
 cd /src/
 
-export DOORMAN_ENV=prod
+if [ -z $DOORMAN_ENV ]; then
+  export DOORMAN_ENV=prod
+fi
 export DOORMAN_SETTINGS=$PWD/settings.cfg
 
 exec chpst \


### PR DESCRIPTION
If DOORMAN_ENV is passed in via docker environment variable, use that.