### PR TITLE
Periodically check when a node last checked in and submitted results

### DIFF
--- a/doorman/extensions.py
+++ b/doorman/extensions.py
@@ -163,10 +163,6 @@ class RuleManager(object):
         for alerter, match in to_trigger:
             self.alerters[alerter].handle_alert(node, match)
 
-    def handle_enroll(self, node):
-        for alerter in self.alerters.values():
-            alerter.handle_enroll(node)
-
 
 def make_celery(app, celery):
     """ From http://flask.pocoo.org/docs/0.10/patterns/celery/ """

--- a/doorman/plugins/alerters/base.py
+++ b/doorman/plugins/alerters/base.py
@@ -13,7 +13,3 @@ class AbstractAlerterPlugin(with_metaclass(ABCMeta)):
     @abstractmethod
     def handle_alert(self, node, match):
         raise NotImplementedError()
-
-    @abstractmethod
-    def handle_enroll(self, node):
-        raise NotImplementedError()

--- a/doorman/plugins/alerters/debug.py
+++ b/doorman/plugins/alerters/debug.py
@@ -22,6 +22,3 @@ class DebugAlerter(AbstractAlerterPlugin):
     def handle_alert(self, node, match):
         # TODO(andrew-d): better message?
         current_app.logger.log(self.level, 'Triggered alert: {0!r}'.format(match))
-
-    def handle_enroll(self, node):
-        current_app.logger.log(self.level, 'Node enrolled: {0!r}'.format(node))

--- a/doorman/plugins/alerters/emailer.py
+++ b/doorman/plugins/alerters/emailer.py
@@ -48,36 +48,3 @@ class EmailAlerter(AbstractAlerterPlugin):
         )
 
         return mail.send(message)
-
-    def handle_enroll(self, node):
-        subject_template = self.config.setdefault(
-            'enroll_subject_template', 'email/enroll.subject.txt'
-        )
-        message_template = self.config.setdefault(
-            'enroll_message_template', 'email/enroll.body.txt'
-        )
-        subject_prefix = self.config.setdefault(
-            'enroll_subject_prefix', '[Doorman]'
-        )
-
-        subject = render_template(
-            subject_template,
-            prefix=subject_prefix,
-            timestamp=dt.datetime.utcnow(),
-            node=node
-        )
-
-        body = render_template(
-            message_template,
-            timestamp=dt.datetime.utcnow(),
-            node=node
-        )
-
-        message = Message(
-            subject.strip(),
-            recipients=self.recipients,
-            body=body,
-            charset='utf-8',
-        )
-
-        return mail.send(message)

--- a/doorman/plugins/alerters/pagerduty.py
+++ b/doorman/plugins/alerters/pagerduty.py
@@ -69,6 +69,3 @@ class PagerDutyAlerter(AbstractAlerterPlugin):
             self.logger.warn('Could not trigger PagerDuty alert!')
 
         self.logger.debug('Response from PagerDuty: %r', resp.content)
-
-    def handle_enroll(self, node):
-        pass

--- a/doorman/plugins/alerters/sentry.py
+++ b/doorman/plugins/alerters/sentry.py
@@ -49,6 +49,3 @@ class SentryAlerter(AbstractAlerterPlugin):
                 'query': query,
             },
         )
-
-    def handle_enroll(self, node):
-        pass

--- a/doorman/settings.py
+++ b/doorman/settings.py
@@ -34,7 +34,7 @@ class Config(object):
     # will have a new node_key generated, and a different corresponding
     # node record in the database. This will result in stale node entries.
     DOORMAN_EXPECTS_UNIQUE_HOST_ID = True
-    DOORMAN_CHECKIN_INTERVAL = 3600
+    DOORMAN_CHECKIN_INTERVAL = dt.timedelta(seconds=3600)
     DOORMAN_ENROLL_OVERRIDE = 'enroll_secret'
     DOORMAN_PACK_DELIMITER = '/'
     DOORMAN_MINIMUM_OSQUERY_LOG_LEVEL = 0
@@ -73,6 +73,13 @@ class Config(object):
     GRAPHITE_ALLOW = [
         'api.*',
     ]
+
+    CELERYBEAT_SCHEDULE = {
+        'alert-when-node-goes-offline': {
+            'task': 'doorman.tasks.alert_when_node_goes_offline',
+            'schedule': 86400,
+        },
+    }
 
     # You can specify a set of custom logger plugins here.  These plugins will
     # be called for every status or result log that is received, and can

--- a/doorman/tasks.py
+++ b/doorman/tasks.py
@@ -66,7 +66,7 @@ def alert_when_node_goes_offline():
     now = dt.datetime.utcnow()
     calendarTime = now.strftime('%a %b %d %H:%M:%S %Y UTC')
 
-    for processed, node in enumerate(imap(_Node.make, query), 1):
+    for processed, node in enumerate(imap(_Node._make, query), 1):
         entry = {
             'name': 'doorman/tasks/node_offline_checks',
             'calendarTime': calendarTime,

--- a/doorman/tasks.py
+++ b/doorman/tasks.py
@@ -30,3 +30,74 @@ def notify_of_node_enrollment(node):
 def example_task(one, two):
     print('Adding {0} and {1}'.format(one, two))
     return one + two
+
+
+@celery.task()
+def alert_when_node_goes_offline():
+    '''
+    This task is intended to periodically comb the database to identify
+    nodes that have not posted results in some time, checked in for some
+    time, or have not posted results within some time of their last
+    checkin. The purpose of this task is to identify nodes that go offline,
+    or in some cases, nodes with corrupted osquery rocksdb databases.
+    '''
+    from collections import namedtuple
+    from itertools import imap
+    from sqlalchemy import func
+    from doorman.models import db, Node, ResultLog
+    import datetime as dt
+
+    _Node = namedtuple('Node', [
+        'id', 'host_identifier', 'node_info', 'enrolled_on', 'is_active',
+        'last_ip', 'last_checkin', 'last_result',
+    ])
+
+    query = db.session.query(
+        ResultLog.node_id,
+        Node.host_identifier,
+        Node.node_info,
+        Node.enrolled_on,
+        Node.is_active,
+        Node.last_ip,
+        Node.last_checkin,
+        func.max(ResultLog.timestamp),
+    ).join(Node).filter(Node.is_active).group_by(ResultLog.node_id, Node.id)
+
+    now = dt.datetime.utcnow()
+    calendarTime = now.strftime('%a %b %d %H:%M:%S %Y UTC')
+
+    for processed, node in enumerate(imap(_Node.make, query), 1):
+        entry = {
+            'name': 'doorman/tasks/node_offline_checks',
+            'calendarTime': calendarTime,
+            'action': 'triggered',
+        }
+        columns = entry['columns'] = {}
+
+        since_last_result = now - node.last_result
+        since_last_checkin = now - node.last_checkin
+        since_last_checkin_to_last_result = node.last_checkin - node.last_result
+
+        columns['since_last_result_seconds'] = since_last_result.total_seconds()
+        columns['since_last_checkin_seconds'] = since_last_checkin.total_seconds()
+        columns['since_last_checkin_to_last_result_seconds'] = since_last_checkin_to_last_result.total_seconds()
+
+        columns['since_last_result_days'] = since_last_result.days
+        columns['since_last_checkin_days'] = since_last_checkin.days
+        columns['since_last_checkin_to_last_result_days'] = since_last_checkin_to_last_result.days
+
+        columns['since_last_result'] = since_last_result
+        columns['since_last_checkin'] = since_last_checkin
+        columns['since_last_checkin_to_last_result'] = since_last_checkin_to_last_result
+
+        _node = dict(node._asdict())
+        _node['display_name'] = node.node_info.get('display_name') or \
+            node.node_info.get('hostname') or \
+            node.node_info.get('computer_name') or \
+            node.host_identifier
+
+        result = {'data': [entry]}
+        current_app.rule_manager.handle_log_entry(result, _node)
+
+    else:
+        return processed

--- a/doorman/tasks.py
+++ b/doorman/tasks.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from celery import Celery
 from flask import current_app
+import datetime as dt
 
 
 celery = Celery(__name__)
@@ -40,12 +41,26 @@ def alert_when_node_goes_offline():
     time, or have not posted results within some time of their last
     checkin. The purpose of this task is to identify nodes that go offline,
     or in some cases, nodes with corrupted osquery rocksdb databases.
+
+    A rule can be created within Doorman's rules manager to alert on
+    any of the following conditions:
+        - query name: doorman/tasks/node_offline_checks
+        - action: triggered
+        - columns:
+            - since_last_result
+            - since_last_result_days
+            - since_last_result_seconds
+            - since_last_checkin
+            - since_last_checkin_days
+            - since_last_checkin_seconds
+            - since_last_checkin_to_last_result
+            - since_last_checkin_to_last_result_days
+            - since_last_checkin_to_last_result_seconds
     '''
     from collections import namedtuple
     from itertools import imap
     from sqlalchemy import func
     from doorman.models import db, Node, ResultLog
-    import datetime as dt
 
     _Node = namedtuple('Node', [
         'id', 'host_identifier', 'node_info', 'enrolled_on', 'is_active',

--- a/doorman/templates/email/enroll.body.txt
+++ b/doorman/templates/email/enroll.body.txt
@@ -1,9 +1,0 @@
-A new node was enrolled:
-
-Host identifier: {{ node.display_name }}
-Enrolled on: {{ node.enrolled_on }}
-Remote IP address: {{ node.last_ip }}
-
-Review {{ node.display_name }} at {{ url_for('manage.get_node', node_id=node.id, _external=True) }}.
-
----END doorman notification

--- a/doorman/templates/email/enroll.subject.txt
+++ b/doorman/templates/email/enroll.subject.txt
@@ -1,1 +1,0 @@
-{{ prefix | trim }} New node enrolled: {{ node.display_name }}

--- a/doorman/utils.py
+++ b/doorman/utils.py
@@ -176,7 +176,9 @@ def create_query_pack_from_upload(upload):
 
 def get_node_health(node):
     checkin_interval = current_app.config['DOORMAN_CHECKIN_INTERVAL']
-    if (dt.datetime.utcnow() - node.last_checkin).total_seconds() > checkin_interval:
+    if isinstance(checkin_interval, (int, float)):
+        checkin_interval = dt.timedelta(seconds=checkin_interval)
+    if (dt.datetime.utcnow() - node.last_checkin) > checkin_interval:
         return u'danger'
     else:
         return ''

--- a/tests/test_alerters.py
+++ b/tests/test_alerters.py
@@ -113,22 +113,6 @@ class TestEmailerAlerter:
         alerter = EmailAlerter(self.config)
         alerter.handle_alert(node.to_dict(), match)
 
-    def test_will_email_on_node_enrollment(self, node, testapp):
-        from flask_mail import email_dispatched
-
-        expected_subject = '[Doorman Test] New node enrolled: {display_name}'.format(
-            display_name=node.display_name,
-        )
-
-        @email_dispatched.connect
-        def verify(message, app):
-            assert message.subject == expected_subject
-            assert self.recipients == message.recipients
-            assert 'A new node was enrolled:' in message.body
-
-        alerter = EmailAlerter(self.config)
-        alerter.handle_enroll(node.to_dict())
-
 
 class TestSentryAlerter:
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1362,9 +1362,6 @@ class TestRuleEndToEnd:
             def handle_alert(self, node, match):
                 self.calls.append((node, match))
 
-            def handle_enroll(self, node):
-                self.calls.append((node, None))
-
         dummy_alerter = DummyAlerter()
 
         # This patches the appropriate config to create the 'dummy' alerter.  This is a bit ugly :-(


### PR DESCRIPTION
Run nodes through our alert manager so that we can define within the Rule Manager alerts against the following info:

* action: `triggered`
* query name: `doorman/tasks/node_offline_checks`
* columns:
  * `since_last_result`
  * `since_last_result_days`
  * `since_last_result_seconds`
  * `since_last_checkin`
  * `since_last_checkin_days`
  * `since_last_checkin_seconds`
  * `since_last_checkin_to_last_result`
  * `since_last_checkin_to_last_result_days`
  * `since_last_checkin_to_last_result_seconds`

For example, a decent start might be to alert when a node last checked in or submitted a result more than 7 days ago, and alert if the time between the last result and the last check is more than 2 days.

This catches those instances where a node completely goes offline, or rocksdb gets corrupted. In the latter case, we observed osquery continuing to fetch a configuration, but never actually posting any new results.