### PR TITLE
Support simple string subsitutions in email alerts

### DIFF
--- a/doorman/models.py
+++ b/doorman/models.py
@@ -514,6 +514,7 @@ class Rule(SurrogatePK, Model):
             name=self.name, description=self.description or '')
         )
 
+
 class User(UserMixin, SurrogatePK, Model):
 
     username = Column(db.String(80), unique=True, nullable=False)

--- a/doorman/plugins/alerters/emailer.py
+++ b/doorman/plugins/alerters/emailer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime as dt
+import string
 
 from flask import render_template
 from flask_mail import Message
@@ -25,20 +26,29 @@ class EmailAlerter(AbstractAlerterPlugin):
             'subject_prefix', '[Doorman]'
         )
 
-        subject = render_template(
-            subject_template,
-            prefix=subject_prefix,
-            match=match,
-            timestamp=dt.datetime.utcnow(),
-            node=node
-        )
+        params = {}
+        params.update(node)
+        params.update(node.get('node_info', {}))
+        params.update(match.result['columns'])
 
-        body = render_template(
-            message_template,
-            match=match,
-            timestamp=dt.datetime.utcnow(),
-            node=node
-        )
+        subject = string.Template(
+            render_template(
+                subject_template,
+                prefix=subject_prefix,
+                match=match,
+                timestamp=dt.datetime.utcnow(),
+                node=node
+            )
+        ).safe_substitute(**params)
+
+        body = string.Template(
+            render_template(
+                message_template,
+                match=match,
+                timestamp=dt.datetime.utcnow(),
+                node=node
+            )
+        ).safe_substitute(**params)
 
         message = Message(
             subject.strip(),

--- a/tests/test_alerters.py
+++ b/tests/test_alerters.py
@@ -110,6 +110,7 @@ class TestEmailerAlerter:
             assert rule.name in message.body
             assert 'boo' in message.body
             assert 'baz' in message.body
+            assert 'kung = bloo' in message.body
 
         alerter = EmailAlerter(self.config)
         alerter.handle_alert(node.to_dict(), match)


### PR DESCRIPTION
Render email as jinja2 template, then perform safe string substitution on body and subject

* replaces $'s with values from the node attributes or column fields in a result

https://www.python.org/dev/peps/pep-0292/